### PR TITLE
Remove thread spam from fixEnergyRequirements

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/util/StreamUtils.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/util/StreamUtils.java
@@ -40,4 +40,9 @@ public class StreamUtils {
     public static boolean filterVisualMaps(GT_Recipe.GT_Recipe_Map gt_recipe_map) {
         return filterVisualMaps().test(gt_recipe_map);
     }
+
+    public static boolean filterVisualMapsNoInstantiate(GT_Recipe.GT_Recipe_Map gt_recipe_map) {
+        Optional<GT_Recipe> op = gt_recipe_map.mRecipeList.stream().findAny();
+        return op.isPresent() && !op.get().mFakeRecipe;
+    }
 }


### PR DESCRIPTION
Replaced the `parallelStream` call with a `ThreadPoolExecutor`. Also reduced some object spam.



bart pls use less streams



![image](https://user-images.githubusercontent.com/30945458/147394535-028e3ed8-7625-4458-9390-d23c00770605.png)